### PR TITLE
Fix build under clang-15

### DIFF
--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -23,7 +23,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#define _XOPEN_SOURCE 500
+
+/* freebsd requires _XOPEN_SOURCE 600 for snprintf()
+ * for linux it is enough 500 */
+#define _XOPEN_SOURCE 600
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,7 +41,6 @@
 #if defined (__linux__) || defined (__gnu_linux__)
 /* Assuming linux with /dev/cpu/x/msr: */
 #include <unistd.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Build error on freebsd [1]:

    Sep 06 18:40:42 [1106/5912] Building C object contrib/libcpuid-cmake/CMakeFiles/_cpuid.dir/__/libcpuid/libcpuid/rdmsr.c.o
    Sep 06 18:40:42 FAILED: contrib/libcpuid-cmake/CMakeFiles/_cpuid.dir/__/libcpuid/libcpuid/rdmsr.c.o
    Sep 06 18:40:42 /usr/bin/ccache /usr/bin/clang-15 --target=x86_64-pc-freebsd11 --sysroot=/build/cmake/freebsd/../../contrib/sysroot/freebsd-x86_64 -DHAS_RESERVED_IDENTIFIER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DVERSION=\"v0.4.1\" -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -isystem ../contrib/libcpuid -isystem ../contrib/libcxx/include -isystem ../contrib/libcxxabi/include -isystem ../contrib/libunwind/include -fdiagnostics-color=always -Xclang -fuse-ctor-homing  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/build=. -falign-functions=32 -mbranches-within-32B-boundaries  -fdiagnostics-absolute-paths -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4    -D OS_FREEBSD -std=gnu11 -MD -MT contrib/libcpuid-cmake/CMakeFiles/_cpuid.dir/__/libcpuid/libcpuid/rdmsr.c.o -MF contrib/libcpuid-cmake/CMakeFiles/_cpuid.dir/__/libcpuid/libcpuid/rdmsr.c.o.d -o contrib/libcpuid-cmake/CMakeFiles/_cpuid.dir/__/libcpuid/libcpuid/rdmsr.c.o   -c ../contrib/libcpuid/libcpuid/rdmsr.c
    Sep 06 18:40:42 /build/contrib/libcpuid/libcpuid/rdmsr.c:164:2: error: call to undeclared library function 'snprintf' with type 'int (char *, unsigned long, const char *, ...)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    Sep 06 18:40:42         snprintf(msr, MSR_PATH_LEN, "/dev/cpuctl%u", core_num);
    Sep 06 18:40:42         ^
    Sep 06 18:40:42 /build/contrib/libcpuid/libcpuid/rdmsr.c:164:2: note: include the header <stdio.h> or explicitly provide a declaration for 'snprintf'
    Sep 06 18:40:42 1 error generated.

  [1]: https://s3.amazonaws.com/clickhouse-builds/41046/0e9265ad951d40cdce3716fb8a679360b2e0c156/binary_freebsd/build_log.log

Refs: https://github.com/ClickHouse/ClickHouse/pull/41046
Upstream: https://github.com/anrieff/libcpuid/pull/167